### PR TITLE
Add error message to 409 conflict. Dev deployment addition

### DIFF
--- a/deployment/templates/buildconfig.yaml
+++ b/deployment/templates/buildconfig.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.development }}
+{{- if and .Values.development .Values.buildImage }}
 apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:

--- a/deployment/templates/imagestream.yaml
+++ b/deployment/templates/imagestream.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   lookupPolicy:
     local: false
-  {{- if not .Values.development}}
+  {{- if not .Values.buildImage}}
   tags:
   - annotations: null
     from:

--- a/deployment/values-dev.yaml
+++ b/deployment/values-dev.yaml
@@ -1,5 +1,7 @@
 name: lodestar-hosting
 development: true
+#if using quay then you should specify the image location
+buildImage: true
 
 imageName: "lodestar-hosting"
 imageTag: "latest"

--- a/src/main/java/com/redhat/labs/lodestar/hosting/service/HostingService.java
+++ b/src/main/java/com/redhat/labs/lodestar/hosting/service/HostingService.java
@@ -12,6 +12,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.transaction.Transactional;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
 
 import com.google.gson.*;
 import com.redhat.labs.lodestar.hosting.model.*;
@@ -188,7 +189,8 @@ public class HostingService {
             }
 
             if(hostingEnv.getOcpSubDomain() != null && !isValidSubdomain(engagementUuid, hostingEnv.getOcpSubDomain())) {
-                throw new WebApplicationException(409);
+                String message = String.format("Subdomain name %s is invalid", hostingEnv.getOcpSubDomain());
+                throw new WebApplicationException(Response.status(409).entity(Map.of("lodestarMessage", message)).build());
             }
             fillOutHostingEnvironment(hostingEnv, engagement.getUuid(), engagement.getRegion(), engagement.getProjectId());
         }

--- a/src/test/java/com/redhat/labs/lodestar/hosting/resource/HostingResourceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/hosting/resource/HostingResourceTest.java
@@ -61,7 +61,7 @@ class HostingResourceTest {
         he.get(0).setOcpSubDomain("red-1");
 
         given().contentType(ContentType.JSON).pathParam("engagementUuid", "second").body(he).put("/engagements/{engagementUuid}").then()
-                .statusCode(409);
+                .statusCode(409).body("lodestarMessage", equalTo("Subdomain name red-1 is invalid"));
     }
 
     @Test


### PR DESCRIPTION
- Sets a message when a subdomain clash occurs. Ex `Subdomain name red-1 is invalid`
- Adds ability to deploy in `dev` mode without a bc. This will allow a dev deployment of the full stack to be ready quicker.